### PR TITLE
 Fix to car model gazebo plugin

### DIFF
--- a/fssim_gazebo_plugins/gazebo_race_car_model/src/vehicle.cpp
+++ b/fssim_gazebo_plugins/gazebo_race_car_model/src/vehicle.cpp
@@ -201,7 +201,7 @@ State Vehicle::f_kin_correction(const State &x_in,
     const double v_blend = 0.5 * (v - 1.5);
     const double blend   = std::fmax(std::fmin(1.0, v_blend), 0.0);
 
-    x.v_x = blend * x.v_x + (1.0 - blend) * x_state.v_x + dt * v_x_dot;
+    x.v_x = blend * x.v_x + (1.0 - blend) * (x_state.v_x + dt * v_x_dot);
 
     const double v_y = std::tan(u.delta) * x.v_x * param_.kinematic.l_R / param_.kinematic.l;
     const double r   = std::tan(u.delta) * x.v_x / param_.kinematic.l;


### PR DESCRIPTION
At speed greater than 1 m/s the acceleration of the model was double of the correct one since the speed increase predicted by the kinematic model was always added to the speed predicted by the dynamical model.

Added parentheses and arranged the precedence between the operations in the function f_kin_correction used to blend the kinematic with the dynamic model at low speed.