### PR TITLE
fix some catkin_make errors and warnings

### DIFF
--- a/fssim_gazebo_plugins/gazebo_cone_sensor/CMakeLists.txt
+++ b/fssim_gazebo_plugins/gazebo_cone_sensor/CMakeLists.txt
@@ -26,20 +26,16 @@ add_library(gazebo_cone_sensor SHARED
 
 target_include_directories(gazebo_cone_sensor PUBLIC
         include
-        ${CMAKE_SOURCE_DIR}
+        ${PROJECT_SOURCE_DIR}
         ${EIGEN3_INCLUDE_DIR}
         ${catkin_INCLUDE_DIRS}
         ${GAZEBO_INCLUDE_DIRS}
         ${PCL_INCLUDE_DIRS})
-
 target_link_libraries(gazebo_cone_sensor
         ${GAZEBO_LIBRARIES}
         ${IGNITION-MSGS_LIBRARIES}
         yaml-cpp
-        gazebo_utils
-        ${catkin_LIBRARY_DIRS}
-        ${EIGEN3_INCLUDE_DIR}
-        ${PCL_INCLUDE_DIRS})
+        gazebo_utils)
 
 install(TARGETS gazebo_cone_sensor
         ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/fssim_gazebo_plugins/gazebo_race_car_model/CMakeLists.txt
+++ b/fssim_gazebo_plugins/gazebo_race_car_model/CMakeLists.txt
@@ -38,7 +38,7 @@ add_library(gazebo_race_car_model SHARED
         src/vehicle.cpp
         src/wheel.cpp
         src/axle.cpp)
-target_include_directories(gazebo_race_car_model PUBLIC include ${CMAKE_SOURCE_DIR} ${catkin_LIBRARY_DIRS})
+    target_include_directories(gazebo_race_car_model PUBLIC include ${PROJECT_SOURCE_DIR})
 target_link_libraries(gazebo_race_car_model ${GAZEBO_LIBRARIES} ${IGNITION-MSGS_LIBRARIES} yaml-cpp ${catkin_LIBRARIES} ${OGRE_LIBRARY})
 
 install(TARGETS gazebo_race_car_model

--- a/fssim_gazebo_plugins/gazebo_track/CMakeLists.txt
+++ b/fssim_gazebo_plugins/gazebo_track/CMakeLists.txt
@@ -40,15 +40,13 @@ add_library(gazebo_track SHARED
             src/gazebo_track.cpp)
 target_include_directories(gazebo_track PUBLIC
                            include
-                           ${CMAKE_SOURCE_DIR}
+                           ${PROJECT_SOURCE_DIR}
                            ${EIGEN3_INCLUDE_DIR}
                            ${PCL_INCLUDE_DIRS})
 target_link_libraries(gazebo_track
                       ${GAZEBO_LIBRARIES}
                       ${IGNITION-MSGS_LIBRARIES}
-                      yaml-cpp
-                      ${EIGEN3_INCLUDE_DIR}
-                      ${PCL_INCLUDE_DIRS})
+                      yaml-cpp)
 
 install(TARGETS gazebo_track
         ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/fssim_gazebo_plugins/gazebo_utils/CMakeLists.txt
+++ b/fssim_gazebo_plugins/gazebo_utils/CMakeLists.txt
@@ -41,15 +41,13 @@ add_library(gazebo_utils SHARED
             src/noise.cpp)
 target_include_directories(gazebo_utils PUBLIC
                            include
-                           ${CMAKE_SOURCE_DIR}
+                           ${PROJECT_SOURCE_DIRS}
                            ${EIGEN3_INCLUDE_DIR}
                            ${PCL_INCLUDE_DIRS})
 target_link_libraries(gazebo_utils
                       ${GAZEBO_LIBRARIES}
                       ${IGNITION-MSGS_LIBRARIES}
-                      yaml-cpp
-                      ${EIGEN3_INCLUDE_DIR}
-                      ${PCL_INCLUDE_DIRS})
+                      yaml-cpp)
 
 install(TARGETS gazebo_utils
         ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}


### PR DESCRIPTION
When building the project in a catkin workspace with `catkin_make` instead of `catkin build`, some include errors occurred, where cMake does not find header files in the `gazebo_plugins` package. This can be fixed by including the project's source directory(PROJECT_SOURCE_DIR) instead of CMAKE_SOURCE_DIR.
Also some warnings showed up, when trying to link to the directories in `EIGEN3_INCLUDE_DIRS` and `PCL_INCLUDE_DIR`. These link target's are save to remove as directories can not be linked and cmake ignores them anyway at the moment with the mentioned warning.

It would be nice, if you could merge this into master as well, if it gets accepted.