### PR TITLE
add dependency on messages

### DIFF
--- a/fssim_gazebo_plugins/gazebo_race_car_model/CMakeLists.txt
+++ b/fssim_gazebo_plugins/gazebo_race_car_model/CMakeLists.txt
@@ -41,6 +41,8 @@ add_library(gazebo_race_car_model SHARED
     target_include_directories(gazebo_race_car_model PUBLIC include ${PROJECT_SOURCE_DIR})
 target_link_libraries(gazebo_race_car_model ${GAZEBO_LIBRARIES} ${IGNITION-MSGS_LIBRARIES} yaml-cpp ${catkin_LIBRARIES} ${OGRE_LIBRARY})
 
+add_dependencies(gazebo_race_car_model ${catkin_EXPORTED_TARGETS})
+
 install(TARGETS gazebo_race_car_model
         ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
         LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/fssim_gazebo_plugins/gazebo_track/CMakeLists.txt
+++ b/fssim_gazebo_plugins/gazebo_track/CMakeLists.txt
@@ -47,6 +47,8 @@ target_link_libraries(gazebo_track
                       ${GAZEBO_LIBRARIES}
                       ${IGNITION-MSGS_LIBRARIES}
                       yaml-cpp)
+                      
+add_dependencies(gazebo_track ${catkin_EXPORTED_TARGETS})
 
 install(TARGETS gazebo_track
         ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}


### PR DESCRIPTION
To ensure the fssim messages in fssim_common get build before the other packages, that use them I added an explicit dependency to gazebo_track and the gazebo_race_car_model. Otherwise it could happen, that you get include errors, because some headers for the messages weren't generated yet.
See also: http://docs.ros.org/jade/api/catkin/html/howto/format2/cpp_msg_dependencies.html